### PR TITLE
Add for-upstream workflow

### DIFF
--- a/.github/workflows/upstream-compat.yaml
+++ b/.github/workflows/upstream-compat.yaml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches-ignore:
+    - main
+    - for-upstream/**
+
+jobs:
+  make-upstream-branch:
+    name: Make branch rebased onto upstream
+    env:
+      UPSTREAM_REPOSITORY:  https://github.com/kubermatic/machine-controller.git
+      UPSTREAM_DEST_BRANCH: master
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: configure user name and email
+      run: |
+        git config user.name 'ANEXIA Bot'
+        git config user.email 'github-anx-release@anexia-it.com'
+
+    - name: add upstream remote
+      run:  git remote add upstream $UPSTREAM_REPOSITORY
+
+    - name: fetch upstream repository
+      run:  git fetch upstream
+
+    - name: create new for-upstream branch
+      run: git checkout -B for-upstream/$GITHUB_REF_NAME
+
+    - name: rebase branch onto upstream destination branch
+      run: git rebase --onto upstream/$UPSTREAM_DEST_BRANCH origin/main
+
+    - name: push new for-upstream branch
+      run: git push -u origin for-upstream/$GITHUB_REF_NAME --force


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a Github actions workflow to automatically create upstream-PRable, rebased branches from every branch pushed into this repository, allowing us to change everything in here without having a lot of manual work to bring things upstream again.