### PR TITLE
Anexia: configure client for tracing API requests

### DIFF
--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -44,6 +44,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cloudproviderutil "github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -484,8 +486,11 @@ func (p *provider) SetMetricsForMachines(_ clusterv1alpha1.MachineList) error {
 
 func getClient(token string) (anxclient.Client, error) {
 	tokenOpt := anxclient.TokenFromString(token)
-	client := anxclient.HTTPClient(&http.Client{Timeout: 30 * time.Second})
-	return anxclient.New(tokenOpt, client)
+	httpClient := cloudproviderutil.HTTPClientConfig{
+		Timeout:   30 * time.Second,
+		LogPrefix: "[Anexia API]",
+	}.New()
+	return anxclient.New(tokenOpt, anxclient.HTTPClient(&httpClient))
 }
 
 func getProviderStatus(machine *clusterv1alpha1.Machine) anxtypes.ProviderStatus {

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -80,7 +80,7 @@ func (p *provider) Create(ctx context.Context, machine *clusterv1alpha1.Machine,
 		Machine:      machine,
 	})
 
-	client, err := getClient(config.Token)
+	client, err := getClient(config.Token, machine.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func (p *provider) Get(ctx context.Context, machine *clusterv1alpha1.Machine, _ 
 		return nil, newError(common.InvalidConfigurationMachineError, "failed to parse MachineSpec: %v", err)
 	}
 
-	cli, err := getClient(config.Token)
+	cli, err := getClient(config.Token, machine.Name)
 	if err != nil {
 		return nil, newError(common.InvalidConfigurationMachineError, "failed to create Anexia client: %v", err)
 	}
@@ -425,7 +425,7 @@ func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine
 		return false, newError(common.InvalidConfigurationMachineError, "failed to parse MachineSpec: %v", err)
 	}
 
-	cli, err := getClient(config.Token)
+	cli, err := getClient(config.Token, machine.Name)
 	if err != nil {
 		return false, newError(common.InvalidConfigurationMachineError, "failed to create Anexia client: %v", err)
 	}
@@ -484,11 +484,11 @@ func (p *provider) SetMetricsForMachines(_ clusterv1alpha1.MachineList) error {
 	return nil
 }
 
-func getClient(token string) (anxclient.Client, error) {
+func getClient(token, vmName string) (anxclient.Client, error) {
 	tokenOpt := anxclient.TokenFromString(token)
 	httpClient := cloudproviderutil.HTTPClientConfig{
-		Timeout:   30 * time.Second,
-		LogPrefix: "[Anexia API]",
+		Timeout:   120 * time.Second,
+		LogPrefix: fmt.Sprintf("[Anexia API for VM %q]", vmName),
 	}.New()
 	return anxclient.New(tokenOpt, anxclient.HTTPClient(&httpClient))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This configures the go-anxcloud client to trace API requests, which is very useful for debugging problems. It's not yet clear if this should go upstream.


**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Anexia: trace API requests
```
