### PR TITLE
Add support for named templates in anexia provider

### DIFF
--- a/docs/anexia.md
+++ b/docs/anexia.md
@@ -10,12 +10,16 @@ An example machine deployment can be found here: [examples/anexia-machinedeploym
 
 ## Templates
 
-This provider supports both named templates (via `template`) and templates by identifier (via `templateID`). When using named templates an optional template build identifier (`templateBuild`) can be specified. Omitting `templateBuild` will yield the currently latest available build for the specified named template. Template builds might get replaced by newer builds. Therefore it is recommended to only specify the `template` by name if a pinned build is not required.
+You can configure the template to use by its name (using the attribute `template`) or its identifier (using the attribute `templateID`).
+
+When specifying the template by its name, the template build to use can optionally be set (attribute `templateBuild`). Omitting `templateBuild` will yield the latest available build (at time the time of creating the `Machine`) for the specified named template.
+
+Template identifiers (attribute `templateID`) always link to a given `template`-`templateBuild` combination, so using the identifier in configuration has the same drawback as specifying an exact build to use.
+
+Templates are rotated pretty often to include security patches and other updates. Outdated versions of templates are not retained and get removed after some time. Because of this, we do not recommend using the `templateID` attribute or pinning to a fixed build unless really required.
 
 To retrieve all available templates against a given location:
 
 ```
 https://engine.anexia-it.com/api/vsphere/v1/provisioning/templates.json/<location identifier>/templates?page=1&limit=50&api_key=<API Key>
 ```
-
-Templates are rotated pretty often, to include updates and latest security patches. Outdated versions of templates are not retained as a result and they get removed after some time.

--- a/docs/anexia.md
+++ b/docs/anexia.md
@@ -10,6 +10,8 @@ An example machine deployment can be found here: [examples/anexia-machinedeploym
 
 ## Templates
 
+This provider supports both named templates (via `template`) and templates by identifier (via `templateID`). When using named templates an optional template build identifier (`templateBuild`) can be specified. Omitting `templateBuild` will yield the currently latest available build for the specified named template. Template builds might get replaced by newer builds. Therefore it is recommended to only specify the `template` by name if a pinned build is not required.
+
 To retrieve all available templates against a given location:
 
 ```

--- a/examples/anexia-machinedeployment.yaml
+++ b/examples/anexia-machinedeployment.yaml
@@ -31,8 +31,10 @@ spec:
                 name: machine-controller-anexia
                 key: token
             vlanID: "<< ANEXIA_VLAN_ID >>"
-            # Currently only the flatcar template is supported: 12c28aa7-604d-47e9-83fb-5f1d1f1837b3
-            templateID: "<< ANEXIA_TEMPLATE_ID >>"
+            # Currently only the "Flatcar Linux Stable" template is supported.
+            # Use templateBuild to specify a build. If empty => latest
+            # Alternatively use templateID for a specific template.
+            template: "<< ANEXIA_TEMPLATE_NAME >>"
             locationID: "<< ANEXIA_LOCATION_ID >>"
             cpus: 2
             memory: 2048

--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/ginkgo/v2 v2.6.0 // indirect
+	github.com/onsi/gomega v1.24.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/openshift/api v0.0.0-20211217221424-8779abfbd571 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,7 +529,6 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
@@ -538,6 +537,7 @@ github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7
 github.com/onsi/ginkgo/v2 v2.3.0/go.mod h1:Eew0uilEqZmIEZr8JrvYlvOM7Rr6xzTmMV8AyFNU9d0=
 github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
 github.com/onsi/ginkgo/v2 v2.6.0 h1:9t9b9vRUbFq3C4qKFCGkVuq/fIHji802N1nrtkh1mNc=
+github.com/onsi/ginkgo/v2 v2.6.0/go.mod h1:63DOGlLAH8+REH8jUGdL3YpCpu7JODesutUjdENfUAc=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -549,6 +549,7 @@ github.com/onsi/gomega v1.21.1/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8lu
 github.com/onsi/gomega v1.22.1/go.mod h1:x6n7VNe4hw0vkyYUM4mjIXx3JbLiPaBPNgB7PRQ1tuM=
 github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
+github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20211217221424-8779abfbd571 h1:+ShYlGoPriGahTTFTjQ0RtNXW0srxDodk2STdc238Rk=
@@ -615,6 +616,7 @@ github.com/rollbar/rollbar-go/errors v0.0.0-20210929193720-32947096267e/go.mod h
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10 h1:wsfMs0iv+MJiViM37qh5VEKISi3/ZUq2nNKNdqmumAs=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -23,12 +23,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gophercloud/gophercloud/testhelper"
 	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/mock"
 	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+	vspherev1 "go.anx.io/go-anxcloud/pkg/apis/vsphere/v1"
 	"go.anx.io/go-anxcloud/pkg/client"
 	anxclient "go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/core"
@@ -52,6 +55,12 @@ const TestIdentifier = "TestIdent"
 func TestAnexiaProvider(t *testing.T) {
 	testhelper.SetupHTTP()
 	client, server := anxclient.NewTestClient(nil, testhelper.Mux)
+
+	a := mock.NewMockAPI()
+	a.FakeExisting(&vspherev1.Template{Identifier: "TEMPLATE-ID-OLD-BUILD", Name: "test-template", Build: "b01"})
+	a.FakeExisting(&vspherev1.Template{Identifier: "TEMPLATE-ID", Name: "test-template", Build: "b02"})
+	a.FakeExisting(&vspherev1.Template{Identifier: "WRONG-TEMPLATE-NAME", Name: "Wrong Template Name", Build: "b02"})
+
 	t.Cleanup(func() {
 		testhelper.TeardownHTTP()
 		server.Close()
@@ -59,6 +68,9 @@ func TestAnexiaProvider(t *testing.T) {
 
 	t.Run("Test provision VM", func(t *testing.T) {
 		t.Parallel()
+
+		var lastProvisionedTemplateID string
+
 		testhelper.Mux.HandleFunc("/api/ipam/v1/address/reserve/ip/count.json", func(writer http.ResponseWriter, request *http.Request) {
 			err := json.NewEncoder(writer).Encode(address.ReserveRandomSummary{
 				Data: []address.ReservedIP{
@@ -71,16 +83,24 @@ func TestAnexiaProvider(t *testing.T) {
 			testhelper.AssertNoErr(t, err)
 		})
 
-		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/vm.json/LOCATION-ID/templates/TEMPLATE-ID", func(writer http.ResponseWriter, request *http.Request) {
+		vsphereProvisioningPrefix := "/api/vsphere/v1/provisioning/vm.json/test-location/templates/"
+		testhelper.Mux.HandleFunc(vsphereProvisioningPrefix, func(writer http.ResponseWriter, request *http.Request) {
+			templateID := request.URL.Path[len(vsphereProvisioningPrefix):]
+			if err := a.Get(context.TODO(), &vspherev1.Template{Identifier: templateID}); err != nil {
+				writer.WriteHeader(400)
+				return
+			}
+			lastProvisionedTemplateID = templateID
+
 			testhelper.TestMethod(t, request, http.MethodPost)
 			type jsonObject = map[string]interface{}
 			expectedJSON := map[string]interface{}{
 				"cpu_performance_type": "performance",
 				"hostname":             "TestMachine",
-				"memory_mb":            json.Number("5"),
+				"memory_mb":            json.Number("2"),
 				"network": []jsonObject{
 					{
-						"vlan":     "VLAN-ID",
+						"vlan":     "test-vlan",
 						"nic_type": "vmxnet3",
 						"ips":      []interface{}{"8.8.8.8"},
 					},
@@ -123,38 +143,79 @@ func TestAnexiaProvider(t *testing.T) {
 			testhelper.AssertNoErr(t, err)
 		})
 
-		providerStatus := anxtypes.ProviderStatus{}
-		ctx := createReconcileContext(context.Background(), reconcileContext{
-			Machine: &v1alpha1.Machine{
-				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
-			},
-			Status:   &providerStatus,
-			UserData: "",
-			Config: resolvedConfig{
-				VlanID:     "VLAN-ID",
-				LocationID: "LOCATION-ID",
-				TemplateID: "TEMPLATE-ID",
-				Disks: []resolvedDisk{
-					{
-						RawDisk: anxtypes.RawDisk{
-							Size: 5,
-						},
+		createReconcileContextWithConfig := func(cfg resolvedConfig) reconcileContext {
+			return reconcileContext{
+				Machine: &v1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
+				},
+				Status:   &anxtypes.ProviderStatus{},
+				UserData: "",
+				Config:   cfg,
+				ProviderData: &cloudprovidertypes.ProviderData{
+					Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
+						return nil
 					},
 				},
-				RawConfig: anxtypes.RawConfig{
-					CPUs:   5,
-					Memory: 5,
-				},
-			},
-			ProviderData: &cloudprovidertypes.ProviderData{
-				Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
-					return nil
-				},
-			},
-		})
+			}
+		}
 
-		err := provisionVM(ctx, client)
-		testhelper.AssertNoErr(t, err)
+		type testCase struct {
+			config             anxtypes.RawConfig
+			expectedError      string
+			expectedTemplateID string
+		}
+
+		testCases := []testCase{
+			// fail
+			{
+				// Template name does not exist
+				config:        hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = ""; c.Template.Value = "non-existing-template-name" }),
+				expectedError: "failed to retrieve named template",
+			},
+			{
+				// Template build does not exist
+				config:        hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "test-template"; c.TemplateBuild.Value = "b42" }),
+				expectedError: "failed to retrieve named template",
+			},
+			{
+				// Template ID does not exist
+				config:        hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "non-existing-template-id" }),
+				expectedError: "could not execute VM provisioning request",
+			},
+			// pass
+			{
+				// With template by ID
+				config:             hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "TEMPLATE-ID"; c.Template.Value = "" }),
+				expectedTemplateID: "TEMPLATE-ID",
+			},
+			{
+				// With named template
+				config:             hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "test-template" }),
+				expectedTemplateID: "TEMPLATE-ID",
+			},
+			{
+				// With named template and not latest build
+				config:             hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "test-template"; c.TemplateBuild.Value = "b01" }),
+				expectedTemplateID: "TEMPLATE-ID-OLD-BUILD",
+			},
+		}
+
+		provider := New(nil).(*provider)
+		for _, testCase := range testCases {
+			resolvedConfig, err := provider.resolveConfig(testCase.config)
+			testhelper.AssertNoErr(t, err)
+			t.Log("--------", resolvedConfig.Template, resolvedConfig.TemplateBuild, resolvedConfig.TemplateID)
+			ctx := createReconcileContext(context.Background(), createReconcileContextWithConfig(*resolvedConfig))
+			lastProvisionedTemplateID = ""
+			err = provisionVM(ctx, a, client)
+			if testCase.expectedError == "" {
+				testhelper.AssertNoErr(t, err)
+				testhelper.AssertEquals(t, testCase.expectedTemplateID, lastProvisionedTemplateID)
+			} else {
+				testhelper.AssertErr(t, err)
+				testhelper.AssertEquals(t, true, strings.Contains(err.Error(), testCase.expectedError))
+			}
+		}
 	})
 
 	t.Run("Test is VM Provisioning", func(t *testing.T) {
@@ -209,32 +270,32 @@ func TestAnexiaProvider(t *testing.T) {
 	})
 }
 
+// this generates a full config and allows hooking into it to e.g. remove a value
+func hookableConfig(hook func(*anxtypes.RawConfig)) anxtypes.RawConfig {
+	config := anxtypes.RawConfig{
+		CPUs: 1,
+
+		Memory: 2,
+
+		Disks: []anxtypes.RawDisk{
+			{Size: 5, PerformanceType: newConfigVarString("ENT6")},
+		},
+
+		Token:      newConfigVarString("test-token"),
+		VlanID:     newConfigVarString("test-vlan"),
+		LocationID: newConfigVarString("test-location"),
+		Template:   newConfigVarString("test-template"),
+	}
+
+	if hook != nil {
+		hook(&config)
+	}
+
+	return config
+}
+
 func TestValidate(t *testing.T) {
 	t.Parallel()
-
-	// this generates a full config and allows hooking into it to e.g. remove a value
-	hookableConfig := func(hook func(*anxtypes.RawConfig)) anxtypes.RawConfig {
-		config := anxtypes.RawConfig{
-			CPUs: 1,
-
-			Memory: 2,
-
-			Disks: []anxtypes.RawDisk{
-				{Size: 5, PerformanceType: newConfigVarString("ENT6")},
-			},
-
-			Token:      newConfigVarString("test-token"),
-			VlanID:     newConfigVarString("test-vlan"),
-			LocationID: newConfigVarString("test-location"),
-			TemplateID: newConfigVarString("test-template"),
-		}
-
-		if hook != nil {
-			hook(&config)
-		}
-
-		return config
-	}
 
 	var configCases []ConfigTestCase
 	configCases = append(configCases,
@@ -271,8 +332,12 @@ func TestValidate(t *testing.T) {
 			Error:  errors.New("location id is missing"),
 		},
 		ConfigTestCase{
-			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "" }),
-			Error:  errors.New("template id is missing"),
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "test-template-identifier" }),
+			Error:  errors.New("both 'template' and 'templateID' are set"),
+		},
+		ConfigTestCase{
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "" }),
+			Error:  errors.New("neither 'template' nor 'templateID' are set"),
 		},
 		ConfigTestCase{
 			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.VlanID.Value = "" }),

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -50,15 +50,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const TestIdentifier = "TestIdent"
+const (
+	TestIdentifier   = "TestIdent"
+	testTemplateName = "test-template"
+)
 
 func TestAnexiaProvider(t *testing.T) {
 	testhelper.SetupHTTP()
 	client, server := anxclient.NewTestClient(nil, testhelper.Mux)
 
 	a := mock.NewMockAPI()
-	a.FakeExisting(&vspherev1.Template{Identifier: "TEMPLATE-ID-OLD-BUILD", Name: "test-template", Build: "b01"})
-	a.FakeExisting(&vspherev1.Template{Identifier: "TEMPLATE-ID", Name: "test-template", Build: "b02"})
+	a.FakeExisting(&vspherev1.Template{Identifier: "TEMPLATE-ID-OLD-BUILD", Name: testTemplateName, Build: "b01"})
+	a.FakeExisting(&vspherev1.Template{Identifier: "TEMPLATE-ID", Name: testTemplateName, Build: "b02"})
 	a.FakeExisting(&vspherev1.Template{Identifier: "WRONG-TEMPLATE-NAME", Name: "Wrong Template Name", Build: "b02"})
 
 	t.Cleanup(func() {
@@ -68,9 +71,6 @@ func TestAnexiaProvider(t *testing.T) {
 
 	t.Run("Test provision VM", func(t *testing.T) {
 		t.Parallel()
-
-		var lastProvisionedTemplateID string
-
 		testhelper.Mux.HandleFunc("/api/ipam/v1/address/reserve/ip/count.json", func(writer http.ResponseWriter, request *http.Request) {
 			err := json.NewEncoder(writer).Encode(address.ReserveRandomSummary{
 				Data: []address.ReservedIP{
@@ -83,24 +83,16 @@ func TestAnexiaProvider(t *testing.T) {
 			testhelper.AssertNoErr(t, err)
 		})
 
-		vsphereProvisioningPrefix := "/api/vsphere/v1/provisioning/vm.json/test-location/templates/"
-		testhelper.Mux.HandleFunc(vsphereProvisioningPrefix, func(writer http.ResponseWriter, request *http.Request) {
-			templateID := request.URL.Path[len(vsphereProvisioningPrefix):]
-			if err := a.Get(context.TODO(), &vspherev1.Template{Identifier: templateID}); err != nil {
-				writer.WriteHeader(400)
-				return
-			}
-			lastProvisionedTemplateID = templateID
-
+		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/vm.json/LOCATION-ID/templates/TEMPLATE-ID", func(writer http.ResponseWriter, request *http.Request) {
 			testhelper.TestMethod(t, request, http.MethodPost)
 			type jsonObject = map[string]interface{}
 			expectedJSON := map[string]interface{}{
 				"cpu_performance_type": "performance",
 				"hostname":             "TestMachine",
-				"memory_mb":            json.Number("2"),
+				"memory_mb":            json.Number("5"),
 				"network": []jsonObject{
 					{
-						"vlan":     "test-vlan",
+						"vlan":     "VLAN-ID",
 						"nic_type": "vmxnet3",
 						"ips":      []interface{}{"8.8.8.8"},
 					},
@@ -143,21 +135,42 @@ func TestAnexiaProvider(t *testing.T) {
 			testhelper.AssertNoErr(t, err)
 		})
 
-		createReconcileContextWithConfig := func(cfg resolvedConfig) reconcileContext {
-			return reconcileContext{
-				Machine: &v1alpha1.Machine{
-					ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
-				},
-				Status:   &anxtypes.ProviderStatus{},
-				UserData: "",
-				Config:   cfg,
-				ProviderData: &cloudprovidertypes.ProviderData{
-					Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
-						return nil
+		providerStatus := anxtypes.ProviderStatus{}
+		ctx := createReconcileContext(context.Background(), reconcileContext{
+			Machine: &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
+			},
+			Status:   &providerStatus,
+			UserData: "",
+			Config: resolvedConfig{
+				VlanID:     "VLAN-ID",
+				LocationID: "LOCATION-ID",
+				TemplateID: "TEMPLATE-ID",
+				Disks: []resolvedDisk{
+					{
+						RawDisk: anxtypes.RawDisk{
+							Size: 5,
+						},
 					},
 				},
-			}
-		}
+				RawConfig: anxtypes.RawConfig{
+					CPUs:   5,
+					Memory: 5,
+				},
+			},
+			ProviderData: &cloudprovidertypes.ProviderData{
+				Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
+					return nil
+				},
+			},
+		})
+
+		err := provisionVM(ctx, client)
+		testhelper.AssertNoErr(t, err)
+	})
+
+	t.Run("Test resolve template", func(t *testing.T) {
+		t.Parallel()
 
 		type testCase struct {
 			config             anxtypes.RawConfig
@@ -169,51 +182,45 @@ func TestAnexiaProvider(t *testing.T) {
 			// fail
 			{
 				// Template name does not exist
-				config:        hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = ""; c.Template.Value = "non-existing-template-name" }),
+				config:        hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "non-existing-template-name" }),
 				expectedError: "failed to retrieve named template",
 			},
 			{
 				// Template build does not exist
-				config:        hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "test-template"; c.TemplateBuild.Value = "b42" }),
+				config: hookableConfig(func(c *anxtypes.RawConfig) {
+					c.Template.Value = testTemplateName
+					c.TemplateBuild.Value = "b42"
+				}),
 				expectedError: "failed to retrieve named template",
-			},
-			{
-				// Template ID does not exist
-				config:        hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "non-existing-template-id" }),
-				expectedError: "could not execute VM provisioning request",
 			},
 			// pass
 			{
-				// With template by ID
-				config:             hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "TEMPLATE-ID"; c.Template.Value = "" }),
-				expectedTemplateID: "TEMPLATE-ID",
-			},
-			{
 				// With named template
-				config:             hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "test-template" }),
+				config:             hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = testTemplateName; c.TemplateID.Value = "" }),
 				expectedTemplateID: "TEMPLATE-ID",
 			},
 			{
 				// With named template and not latest build
-				config:             hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "test-template"; c.TemplateBuild.Value = "b01" }),
+				config: hookableConfig(func(c *anxtypes.RawConfig) {
+					c.Template.Value = testTemplateName
+					c.TemplateBuild.Value = "b01"
+				}),
 				expectedTemplateID: "TEMPLATE-ID-OLD-BUILD",
 			},
 		}
 
 		provider := New(nil).(*provider)
 		for _, testCase := range testCases {
-			resolvedConfig, err := provider.resolveConfig(testCase.config)
-			testhelper.AssertNoErr(t, err)
-			t.Log("--------", resolvedConfig.Template, resolvedConfig.TemplateBuild, resolvedConfig.TemplateID)
-			ctx := createReconcileContext(context.Background(), createReconcileContextWithConfig(*resolvedConfig))
-			lastProvisionedTemplateID = ""
-			err = provisionVM(ctx, a, client)
-			if testCase.expectedError == "" {
-				testhelper.AssertNoErr(t, err)
-				testhelper.AssertEquals(t, testCase.expectedTemplateID, lastProvisionedTemplateID)
+			templateID, err := resolveTemplateID(context.TODO(), a, testCase.config, provider.configVarResolver, "foo")
+			if testCase.expectedError != "" {
+				if err != nil {
+					testhelper.AssertErr(t, err)
+					testhelper.AssertEquals(t, true, strings.Contains(err.Error(), testCase.expectedError))
+					continue
+				}
 			} else {
-				testhelper.AssertErr(t, err)
-				testhelper.AssertEquals(t, true, strings.Contains(err.Error(), testCase.expectedError))
+				testhelper.AssertNoErr(t, err)
+				testhelper.AssertEquals(t, testCase.expectedTemplateID, templateID)
 			}
 		}
 	})
@@ -270,7 +277,7 @@ func TestAnexiaProvider(t *testing.T) {
 	})
 }
 
-// this generates a full config and allows hooking into it to e.g. remove a value
+// this generates a full config and allows hooking into it to e.g. remove a value.
 func hookableConfig(hook func(*anxtypes.RawConfig)) anxtypes.RawConfig {
 	config := anxtypes.RawConfig{
 		CPUs: 1,
@@ -284,7 +291,7 @@ func hookableConfig(hook func(*anxtypes.RawConfig)) anxtypes.RawConfig {
 		Token:      newConfigVarString("test-token"),
 		VlanID:     newConfigVarString("test-vlan"),
 		LocationID: newConfigVarString("test-location"),
-		Template:   newConfigVarString("test-template"),
+		TemplateID: newConfigVarString("test-template-id"),
 	}
 
 	if hook != nil {
@@ -301,7 +308,7 @@ func TestValidate(t *testing.T) {
 	configCases = append(configCases,
 		ConfigTestCase{
 			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.Token.Value = "" }),
-			Error:  errors.New("token is missing"),
+			Error:  errors.New("token not set"),
 		},
 		ConfigTestCase{
 			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.CPUs = 0 }),
@@ -330,14 +337,6 @@ func TestValidate(t *testing.T) {
 		ConfigTestCase{
 			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.LocationID.Value = "" }),
 			Error:  errors.New("location id is missing"),
-		},
-		ConfigTestCase{
-			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "test-template-identifier" }),
-			Error:  errors.New("both 'template' and 'templateID' are set"),
-		},
-		ConfigTestCase{
-			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.Template.Value = "" }),
-			Error:  errors.New("neither 'template' nor 'templateID' are set"),
 		},
 		ConfigTestCase{
 			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.VlanID.Value = "" }),

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -57,7 +57,10 @@ type RawConfig struct {
 	Token      providerconfigtypes.ConfigVarString `json:"token,omitempty"`
 	VlanID     providerconfigtypes.ConfigVarString `json:"vlanID"`
 	LocationID providerconfigtypes.ConfigVarString `json:"locationID"`
-	TemplateID providerconfigtypes.ConfigVarString `json:"templateID"`
+
+	TemplateID    providerconfigtypes.ConfigVarString `json:"templateID"`
+	Template      providerconfigtypes.ConfigVarString `json:"template"`
+	TemplateBuild providerconfigtypes.ConfigVarString `json:"templateBuild"`
 
 	CPUs   int `json:"cpus"`
 	Memory int `json:"memory"`


### PR DESCRIPTION
Signed-off-by: Mario Schäfer <mschaefer@anexia-it.com>

**What this PR does / why we need it**:
This PR adds support for named templates. Template IDs may break over time when a new build is released. With named templates the latest build can be selected without specifying the Template ID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Added support for named templates in anexia provider
```
