### PR TITLE
Metrics node provisioning

### DIFF
--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -155,12 +155,19 @@ type KubeconfigProvider interface {
 // MetricsCollection is a struct of all metrics used in
 // this controller.
 type MetricsCollection struct {
-	Workers prometheus.Gauge
-	Errors  prometheus.Counter
+	Workers        prometheus.Gauge
+	Errors         prometheus.Counter
+	Provisioning   prometheus.Histogram
+	Deprovisioning prometheus.Histogram
 }
 
 func (mc *MetricsCollection) MustRegister(registerer prometheus.Registerer) {
-	registerer.MustRegister(mc.Errors, mc.Workers)
+	registerer.MustRegister(
+		mc.Errors,
+		mc.Workers,
+		mc.Provisioning,
+		mc.Deprovisioning,
+	)
 }
 
 func Add(
@@ -458,6 +465,9 @@ func (r *Reconciler) ensureMachineHasNodeReadyCondition(machine *clusterv1alpha1
 			return nil
 		}
 	}
+
+	r.metrics.Provisioning.Observe(time.Until(machine.CreationTimestamp.Time).Abs().Seconds())
+
 	return r.updateMachine(machine, func(m *clusterv1alpha1.Machine) {
 		m.Status.Conditions = append(m.Status.Conditions, corev1.NodeCondition{Type: corev1.NodeReady,
 			Status: corev1.ConditionTrue,
@@ -595,7 +605,13 @@ func (r *Reconciler) deleteMachine(ctx context.Context, prov cloudprovidertypes.
 		return nil, err
 	}
 
-	return nil, r.deleteNodeForMachine(ctx, nodes, machine)
+	if err := r.deleteNodeForMachine(ctx, nodes, machine); err != nil {
+		return nil, err
+	}
+
+	r.metrics.Deprovisioning.Observe(time.Until(machine.DeletionTimestamp.Time).Abs().Seconds())
+
+	return nil, nil
 }
 
 func (r *Reconciler) retrieveNodesRelatedToMachine(ctx context.Context, machine *clusterv1alpha1.Machine) ([]*corev1.Node, error) {

--- a/pkg/controller/machine/metrics.go
+++ b/pkg/controller/machine/metrics.go
@@ -50,6 +50,16 @@ func NewMachineControllerMetrics() *MetricsCollection {
 			Name: metricsPrefix + "errors_total",
 			Help: "The total number or unexpected errors the controller encountered",
 		}),
+		Provisioning: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    metricsPrefix + "provisioning_time_seconds",
+			Help:    "Histogram of times spent from creating a Machine to ready state in the cluster",
+			Buckets: prometheus.ExponentialBuckets(32, 1.5, 10),
+		}),
+		Deprovisioning: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    metricsPrefix + "deprovisioning_time_seconds",
+			Help:    "Histogram of times spent from deleting a Machine to be removed from cluster and cloud provider",
+			Buckets: prometheus.ExponentialBuckets(32, 1.5, 10),
+		}),
 	}
 
 	// Set default values, so that these metrics always show up


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds 2 new histograms to the `/metrics` endpoint
- `machine_controller_provisioning_machines_time_seconds`
- `machine_controller_deprovisioning_machines_time_seconds`

## machine_controller_provisioning_machines_time_seconds

Time spent from getting the request to add a new node to the cluster to when the node is fully provisioned and in ready-state

## machine_controller_deprovisioning_machines_time_seconds

Time spent from getting the request to remove a node from the cluster to when the node is drained and the machine deleted from the cloud provider

