### PR TITLE
Postpone machine cleanup when instance is still being created

### DIFF
--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -29,6 +29,7 @@ import (
 
 type anexiaInstance struct {
 	isCreating        bool
+	isDeleting        bool
 	info              *info.Info
 	reservedAddresses []string
 }
@@ -86,6 +87,9 @@ func (ai *anexiaInstance) Addresses() map[string]v1.NodeAddressType {
 }
 
 func (ai *anexiaInstance) Status() instance.Status {
+	if ai.isDeleting {
+		return instance.StatusDeleting
+	}
 	if ai.isCreating {
 		return instance.StatusCreating
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a race condition in our providers Cleanup method - introduced in https://github.com/anexia-it/machine-controller/pull/10 - which occurs when a machine is deleted before the instance has been created.